### PR TITLE
fix: Change `Display` text of `Event::CommandTooLong`

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -577,6 +577,6 @@ pub enum Error {
     MalformedMessage { discarded_bytes: Secret<Box<[u8]>> },
     #[error("Literal was rejected because it was too long")]
     LiteralTooLong { discarded_bytes: Secret<Box<[u8]>> },
-    #[error("Command was rejected because it was too long")]
+    #[error("Command is too long")]
     CommandTooLong { discarded_bytes: Secret<Box<[u8]>> },
 }


### PR DESCRIPTION
The current text might imply that the command was somehow automatically rejected, similar to `Error::LiteralTooLong`. But that's not the case. The user is responsible for sending a BAD.