### PR TITLE
build: Adjust feature flags to fix flanky CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ stream = ["dep:rustls", "dep:tokio", "dep:tokio-rustls"]
 bounded-static = "0.5.0"
 bytes = "1.6.0"
 imap-codec = { version = "2.0.0-alpha.1", features = ["starttls", "quirk_crlf_relaxed", "bounded-static", "ext_condstore_qresync", "ext_login_referrals", "ext_mailbox_referrals", "ext_id", "ext_sort_thread", "ext_binary", "ext_metadata", "ext_uidplus"] }
-imap-types = { version = "2.0.0-alpha.1", features = ["starttls", "ext_condstore_qresync", "ext_login_referrals", "ext_mailbox_referrals", "ext_id", "ext_sort_thread", "ext_binary", "ext_metadata", "ext_uidplus"] }
+imap-types = { version = "2.0.0-alpha.1", features = ["starttls", "bounded-static", "ext_condstore_qresync", "ext_login_referrals", "ext_mailbox_referrals", "ext_id", "ext_sort_thread", "ext_binary", "ext_metadata", "ext_uidplus"] }
 rustls = { version = "0.23.9", optional = true }
 thiserror = "1.0.61"
 tokio = { version = "1.38.0", optional = true, features = ["io-util", "macros", "net"] }


### PR DESCRIPTION
The feature flag `bounded-static` for `imap-types` is currently set transitively by `imap-codec`. I suspect that this lead to obscure CI failures like [this one](https://github.com/duesee/imap-next/actions/runs/9727632425):

```
    Checking imap-next v0.1.0 (/home/runner/work/imap-next/imap-next)
error[E0277]: the trait bound `for<'a> imap_types::response::Greeting<'a>: bounded_static::IntoBoundedStatic` is not satisfied
   --> src/client.rs:110:33
    |
110 |                     match state.next() {
    |                                 ^^^^ the trait `for<'a> bounded_static::IntoBoundedStatic` is not implemented for `imap_types::response::Greeting<'a>`
```

Or this even a cargo bug? I'm very confused.