### PR TITLE
refactor(proxy): General cleanup of implementation and logging

### DIFF
--- a/proxy/src/util.rs
+++ b/proxy/src/util.rs
@@ -12,11 +12,6 @@ use thiserror::Error;
 use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use tracing::warn;
 
-pub enum ControlFlow {
-    Continue,
-    Abort,
-}
-
 /// Remove unsupported capabilities in a greetings `Code::Capability`.
 pub fn filter_capabilities_in_greeting(greeting: &mut Greeting) {
     if let Some(Code::Capability(capabilities)) = &mut greeting.code {


### PR DESCRIPTION
This is a subset of #241 that just clean up the implementation of the proxy and fixes some minor logging issues.