### PR TITLE
chore: forward features to `imap-codec`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,7 +190,9 @@ version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
+ "arbitrary",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -202,6 +213,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -272,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "imap-codec"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8223b81b583119c2178681cb1d7fff8485ee0b88bb26aaf06a9dee29b4579fed"
+checksum = "204c4816456f1a732d55bb42d90bac69538588dcdf3ef8c9a90b5ca02397021a"
 dependencies = [
  "abnf-core",
  "base64",
@@ -290,7 +312,7 @@ version = "0.2.0"
 dependencies = [
  "bytes",
  "imap-codec",
- "imap-types",
+ "imap-next",
  "rand",
  "rustls",
  "thiserror",
@@ -305,11 +327,13 @@ version = "2.0.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20a1a5a918696bcc51132d4b96f9dd872517e70fcb7a7b8082f0edcd83a84eeb"
 dependencies = [
+ "arbitrary",
  "base64",
  "bounded-static",
  "bounded-static-derive",
  "chrono",
  "rand",
+ "serde",
  "thiserror",
 ]
 
@@ -723,6 +747,26 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.204"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.204"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "sharded-slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,28 +14,34 @@ default = ["stream"]
 expose_stream = []
 stream = ["dep:bytes", "dep:rustls", "dep:tokio", "dep:tokio-rustls"]
 
+# <Forward to imap-codec>
+arbitrary = ["imap-codec/arbitrary"]
+arbitrary_simplified = ["imap-codec/arbitrary_simplified"]
+serde = ["imap-codec/serde"]
+tag_generator = ["imap-codec/tag_generator"]
+
+# IMAP
+starttls = ["imap-codec/starttls"]
+ext_condstore_qresync = ["imap-codec/ext_condstore_qresync"]
+ext_id = ["imap-codec/ext_id"]
+ext_login_referrals = ["imap-codec/ext_login_referrals"]
+ext_mailbox_referrals = ["imap-codec/ext_mailbox_referrals"]
+ext_metadata = ["imap-codec/ext_metadata"]
+# </Forward to imap-codec>
+
 [dependencies]
 bytes = { version = "1.6.1", optional = true }
+imap-codec = { version = "2.0.0-alpha.4", features = ["quirk_crlf_relaxed"] }
 rustls = { version = "0.23.12", optional = true }
 thiserror = "1.0.63"
 tokio = { version = "1.39.1", optional = true, features = ["io-util", "macros", "net"] }
 tokio-rustls = { version = "0.26.0", optional = true }
 tracing = "0.1.40"
 
-[dependencies.imap-codec]
-version = "2.0.0-alpha.3"
-features = [
-    "quirk_crlf_relaxed",
-    "starttls",
-    #"ext_condstore_qresync",
-    "ext_id",
-    #"ext_login_referrals",
-    #"ext_mailbox_referrals",
-    "ext_metadata",
-]
-
 [dev-dependencies]
-imap-types = { version = "2.0.0-alpha.3", features = ["tag_generator"] }
+# We want to enable `tag_generator` for examples.
+imap-next = { path = ".", features = ["tag_generator"] }
+
 rand = "0.8.5"
 tokio = { version = "1.39.1", features = ["full"] }
 

--- a/integration-test/Cargo.toml
+++ b/integration-test/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 bstr = { version = "1.9.1", default-features = false }
 bytes = "1.6.1"
-imap-codec = { version = "2.0.0-alpha.3" }
+imap-codec = { version = "2.0.0-alpha.4" }
 imap-next = { path = ".." }
 tokio = { version = "1.39.1", features = ["macros", "net", "rt", "time"] }
 tracing = "0.1.40"


### PR DESCRIPTION
This won't work until [I](https://github.com/duesee/imap-codec/pull/567) is merged and `imap-codec 2.0.0-alpha.4` is published. This is how it would look like. I made this PR so that we can discuss.

Closes #257.